### PR TITLE
Fix programs' names & display names

### DIFF
--- a/OrderedClustering/description-wsDDv2.xml
+++ b/OrderedClustering/description-wsDDv2.xml
@@ -2,7 +2,7 @@
 <program_description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:noNamespaceSchemaLocation="../../docs/w3-ws/specificationData/description.xsd">
 
-    <program provider="PUT" name="orderedClustering" displayName="OrderedClustering" version="0.2.0" />
+    <program provider="PUT" name="orderedClustering" displayName="orderedClustering" version="0.2.0" />
     <documentation>
         <description>OrderedClustering - clustering method using graphs and  flows</description>
         <url>https://github.com/dohko93/mcdm/tree/master/OrderedClustering</url>

--- a/OrderedClustering/description-wsDDv3.xml
+++ b/OrderedClustering/description-wsDDv3.xml
@@ -2,7 +2,7 @@
 <program_description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:noNamespaceSchemaLocation="../../docs/w3-ws/specificationData/description.xsd">
 
-    <program provider="PUT" name="orderedClustering" displayName="OrderedClustering" version="0.2.0" />
+    <program provider="PUT" name="orderedClustering" displayName="orderedClustering" version="0.2.0" />
     <documentation>
         <description>OrderedClustering - clustering method using graphs and  flows</description>
         <url>https://github.com/dohko93/mcdm/tree/master/OrderedClustering</url>

--- a/P2CLUST/description-wsDDv2.xml
+++ b/P2CLUST/description-wsDDv2.xml
@@ -2,7 +2,7 @@
 <program_description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:noNamespaceSchemaLocation="../../docs/w3-ws/specificationData/description.xsd">
 
-    <program provider="PUT" name="prometheeIIOrderedClustering" displayName="PrometheeIIOrderedClustering" version="0.2.1" />
+    <program provider="PUT" name="PrometheeIIOrderedClustering" displayName="PrometheeIIOrderedClustering" version="0.2.1" />
     <documentation>
         <description>Clustering using Promethee II and k-means algorithm</description>
         <url>https://github.com/dohko93/mcdm/tree/master/P2CLUST</url>

--- a/P2CLUST/description-wsDDv3.xml
+++ b/P2CLUST/description-wsDDv3.xml
@@ -2,7 +2,7 @@
 <program_description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:noNamespaceSchemaLocation="../../docs/w3-ws/specificationData/description.xsd">
 
-    <program provider="PUT" name="prometheeIIOrderedClustering" displayName="PrometheeIIOrderedClustering" version="0.2.1" />
+    <program provider="PUT" name="PrometheeIIOrderedClustering" displayName="PrometheeIIOrderedClustering" version="0.2.1" />
     <documentation>
         <description>Clustering using Promethee II and k-means algorithm</description>
         <url>https://github.com/dohko93/mcdm/tree/master/P2CLUST</url>

--- a/P3CLUST/description-wsDDv2.xml
+++ b/P3CLUST/description-wsDDv2.xml
@@ -2,7 +2,7 @@
 <program_description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:noNamespaceSchemaLocation="../../docs/w3-ws/specificationData/description.xsd">
 
-    <program provider="PUT" name="prometheeCluster" displayName="PrometheeCluster" version="0.2.1" />
+    <program provider="PUT" name="PrometheeCluster" displayName="PrometheeCluster" version="0.2.1" />
     <documentation>
         <description>Clustering using Promethee Tri and k-means algorithm
         </description>

--- a/P3CLUST/description-wsDDv3.xml
+++ b/P3CLUST/description-wsDDv3.xml
@@ -2,7 +2,7 @@
 <program_description xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xsi:noNamespaceSchemaLocation="../../docs/w3-ws/specificationData/description.xsd">
 
-    <program provider="PUT" name="prometheeCluster" displayName="PrometheeCluster" version="0.2.1" />
+    <program provider="PUT" name="PrometheeCluster" displayName="PrometheeCluster" version="0.2.1" />
     <documentation>
         <description>Clustering using Promethee Tri and k-means algorithm</description>
         <url>https://github.com/dohko93/mcdm/tree/master/P3CLUST</url>


### PR DESCRIPTION
- Acronyms should start with an uppercase
- name and displayName should be equal (there are exceptions to this rule, but for legacy WS only)